### PR TITLE
解决Github Docker build不通过的问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Pyrogram
 TgCrypto
 ffmpeg-python
 psutil
-pytgcalls[pyrogram]
+pytgcalls
 wheel
 python-arq
 youtube_dl


### PR DESCRIPTION
#23 4.467 Collecting tgcalls==1.0.0 (from pytgcalls[pyrogram]->-r requirements.txt (line 5))
2714
#23 4.503   Could not find a version that satisfies the requirement tgcalls==1.0.0 (from pytgcalls[pyrogram]->-r requirements.txt (line 5)) (from versions: )
2715
#23 4.591 No matching distribution found for tgcalls==1.0.0 (from pytgcalls[pyrogram]->-r requirements.txt (line 5))
2716
#23 ERROR: process "/bin/sh -c pip3 install -U -r requirements.txt" did not complete successfully: exit code: 1

fix #11